### PR TITLE
fix: rename the ingress-http-domain option to ingress-http-url

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -20,7 +20,7 @@ const parse = (canonicalArgv, callback, args = {}) => {
         .showHidden('show-hidden', 'Show hidden options')
         .group([
             'ingress',
-            'ingress-http-domain',
+            'ingress-http-url',
             'ingress-http-port',
             'ingress-sni-port',
             'ingress-sni-host',
@@ -33,10 +33,11 @@ const parse = (canonicalArgv, callback, args = {}) => {
             default: 'http',
             choices: ['http', 'sni'],
         })
-        .option('ingress-http-domain', {
+        .option('ingress-http-url', {
             type: 'string',
-            describe: 'Wildcard domain for HTTP ingress',
+            describe: 'Base URL to use for the HTTP ingress',
             example: 'https://tun.example.com creates https://<tunnel-id>.tun.example.com ingress points)',
+            default: args['ingress-http-domain'],
             required: args['ingress']?.includes('http'),
             coerce: (url) => {
                 return typeof url == 'string' ? new URL(url) : url;
@@ -326,12 +327,21 @@ const parse = (canonicalArgv, callback, args = {}) => {
             },
         })
         .group([
-            'redis-url'
+            'redis-url',
+            'ingress-http-domain'
         ], 'Deprecated options')
         .option('redis-url', {
             type: 'string',
             hidden: true,
             description: '[DEPRECATED] Redis connection URL. Use --storage-redis-url and/or --cluster-redis-url',
+            coerce: (url) => {
+                return typeof url == 'string' ? new URL(url) : url;
+            },
+        })
+        .option('ingress-http-domain', {
+            type: 'string',
+            hidden: true,
+            describe: '[DEPRECATED] Use --ingress-http-url instead',
             coerce: (url) => {
                 return typeof url == 'string' ? new URL(url) : url;
             },

--- a/src/index.js
+++ b/src/index.js
@@ -95,7 +95,7 @@ export default async (argv) => {
                 http: {
                     enabled: config.get('ingress').includes('http'),
                     port: config.get('ingress-http-port'),
-                    subdomainUrl: config.get('ingress-http-domain')
+                    subdomainUrl: config.get('ingress-http-url')
                 },
                 sni: {
                     enabled: config.get('ingress').includes('sni'),

--- a/test/e2e/test_api.js
+++ b/test/e2e/test_api.js
@@ -15,7 +15,7 @@ describe('API test', () => {
             "--admin-enable",
             "--allow-registration",
             "--ingress", "http",
-            "--ingress-http-domain", "http://localhost:8080"
+            "--ingress-http-url", "http://localhost:8080"
         ]);
     });
 

--- a/test/e2e/test_cluster.js
+++ b/test/e2e/test_cluster.js
@@ -95,7 +95,7 @@ describe('Cluster E2E', () => {
                 "--storage-redis-url", redisUrl, 
                 "--allow-registration",
                 "--ingress", "http",
-                "--ingress-http-domain", "http://localhost:8080",
+                "--ingress-http-url", "http://localhost:8080",
             ].concat(args), [
                 "-p", "8080:8080"
             ]);
@@ -106,7 +106,7 @@ describe('Cluster E2E', () => {
                 "--storage-redis-url", redisUrl, 
                 "--allow-registration",
                 "--ingress", "http",
-                "--ingress-http-domain", "http://localhost:8080",
+                "--ingress-http-url", "http://localhost:8080",
             ].concat(args));
 
             const echoServerTerminate = await createEchoServer();

--- a/test/e2e/test_ssh.js
+++ b/test/e2e/test_ssh.js
@@ -19,7 +19,7 @@ describe('SSH transport E2E', () => {
             "--allow-registration",
             "--transport", "ssh",
             "--ingress", "http",
-            "--ingress-http-domain", "http://localhost:8080"
+            "--ingress-http-url", "http://localhost:8080"
         ]);
         echoServerTerminator = await createEchoServer();
     });

--- a/test/e2e/test_ws.js
+++ b/test/e2e/test_ws.js
@@ -18,7 +18,7 @@ describe('Websocket E2E', () => {
             "--admin-enable",
             "--allow-registration",
             "--ingress", "http",
-            "--ingress-http-domain", "http://localhost:8080"
+            "--ingress-http-url", "http://localhost:8080"
         ]);
         echoServerTerminator = await createEchoServer();
     });


### PR DESCRIPTION
The option takes a URL, not a domain. Reflect this by calling the option ingress-http-url.