### PR TITLE
Simplify storage configuration

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -6,6 +6,11 @@ on:
       - '!master'
 
   workflow_dispatch:
+    inputs:
+      publish_container:
+        description: 'Publish container'
+        required: true
+        default: 'false'
 
 jobs:
   build_and_test:
@@ -31,3 +36,24 @@ jobs:
             make image.build
             docker run --rm -t $(make get.image) --version | grep $(make get.version)
             docker run --rm -t -e EXPOSR_SELF_TEST=1 $(make get.image)
+
+      - name: Set up QEMU
+        if: github.event.inputs.publish_container == 'true'
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        if: github.event.inputs.publish_container == 'true'
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to hub.docker.com
+        if: github.event.inputs.publish_container == 'true'
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
+      - name: Publish versioned container to hub.docker.com
+        if: github.event.inputs.publish_container == 'true'
+        run:  |
+          make publish=true image.xbuild

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -39,19 +39,11 @@ data:
 {{- if eq .Values.exposr.cluster.type "udp"}}
   EXPOSR_CLUSTER_UDP_DISCOVERY: "{{ .Values.exposr.cluster.udp.discovery }}"
 {{- end }}
-  EXPOSR_STORAGE: "{{ .Values.exposr.storage.type }}"
-{{- if eq .Values.exposr.storage.type "redis" }}
-{{- if .Values.exposr.storage.redis.url }}
-  EXPOSR_STORAGE_REDIS_URL: "{{ .Values.exposr.storage.redis.url }}"
-{{- end }}
-{{- end }}
-{{- if eq .Values.exposr.storage.type "pgsql" }}
-{{- if .Values.exposr.storage.pgsql.url }}
-  EXPOSR_STORAGE_PGSQL_URL: "{{ .Values.exposr.storage.pgsql.url }}"
+{{- if .Values.exposr.storage.url }}
+  EXPOSR_STORAGE_URL: "{{ .Values.exposr.storage.url }}"
 {{- end }}
 {{- if .Values.exposr.storage.pgsql.connectionPoolSize }}
   EXPOSR_STORAGE_PGSQL_CONNECTION_POOL_SIZE: "{{ .Values.exposr.storage.pgsql.connectionPoolSize }}"
-{{- end }}
 {{- end }}
   EXPOSR_INGRESS: "{{ join "," $exposrIngress }}"
   EXPOSR_TRANSPORT: "{{ join "," $exposrTransport }}"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -12,8 +12,7 @@ exposr:
     udp:
       discovery: kubernetes
   storage:
-    type: redis
-    redis: {}
+    url: memory:// 
     pgsql: {}
   transport:
     maxConnections: 2

--- a/src/index.js
+++ b/src/index.js
@@ -30,16 +30,12 @@ export default async (argv) => {
     // Initialize storage and cluster service
     const storageServiceReady = new Promise((resolve, reject) => {
         try {
-            const type = config.get('storage');
-
-            const storage = new StorageService(type, {
+            const storage = new StorageService({
                 callback: (err) => {
                     err ? reject(err) : resolve(storage);
                 },
-                redisUrl: config.get('storage-redis-url'),
-                sqlitePath: config.get('storage-sqlite-path'),
+                url: config.get('storage-url'),
                 pgsql: {
-                    url: config.get('storage-pgsql-url'),
                     poolSize: config.get('storage-pgsql-connection-pool-size'),
                 }
             });

--- a/src/storage/memory-storage-provider.js
+++ b/src/storage/memory-storage-provider.js
@@ -13,7 +13,6 @@ class MemoryStorageProvider extends StorageProvider {
 
         new Promise((resolve, reject) => {
             const lock = new LockService("mem", {
-                ...opts,
                 callback: (err) => { err ? reject(err) : resolve(lock) },
             });
         }).catch((err) => {

--- a/src/storage/pgsql-storage-provider.js
+++ b/src/storage/pgsql-storage-provider.js
@@ -9,8 +9,8 @@ class PgsqlStorageProvider extends StorageProvider {
         this.expiryCleanInterval = 5 * 60 * 1000;
         this._ns_init = {};
 
-        const url = typeof opts.pgsql.url == 'string' ? new URL(opts.pgsql.url) : opts.pgsql.url;
-        const poolSize = opts.pgsql.poolSize || 10;
+        const url = typeof opts.url == 'string' ? new URL(opts.url) : opts.url;
+        const poolSize = opts.poolSize || 10;
 
         this._db = new Pgsql.Pool({
             connectionString: url.href,

--- a/src/storage/redis-storage-provider.js
+++ b/src/storage/redis-storage-provider.js
@@ -8,7 +8,7 @@ class RedisStorageProvider extends StorageProvider {
     constructor(opts) {
         super();
         this.logger = Logger("redis-storage");
-        const redisUrl = opts.redisUrl;
+        const redisUrl = opts.url;
 
         if (!redisUrl) {
             throw new Error("No Redis connection string provided");
@@ -81,7 +81,7 @@ class RedisStorageProvider extends StorageProvider {
                 }),
             new Promise((resolve, reject) => {
                 const lock = new LockService("redis", {
-                    ...opts,
+                    redisUrl,
                     callback: (err) => { err ? reject(err) : resolve(lock) },
                 });
             })

--- a/src/storage/sqlite-storage-provider.js
+++ b/src/storage/sqlite-storage-provider.js
@@ -8,7 +8,8 @@ class SqliteStorageProvider extends StorageProvider {
         super();
         this.logger = Logger("sqlite-storage");
 
-        const db_file = opts.sqlitePath || "db.sqlite";
+        const url = opts?.url;
+        const db_file = url ? url?.href?.slice(url?.protocol?.length + 2) : "db.sqlite";
         this._db = new Sqlite(db_file)
         this._db.pragma('journal_mode = WAL');
         this.expiryCleanInterval = 5 * 60 * 1000;
@@ -19,7 +20,6 @@ class SqliteStorageProvider extends StorageProvider {
 
         new Promise((resolve, reject) => {
             const lock = new LockService("mem", {
-                ...opts,
                 callback: (err) => { err ? reject(err) : resolve(lock) },
             });
         }).catch((err) => {

--- a/test/e2e/test_cluster.js
+++ b/test/e2e/test_cluster.js
@@ -91,8 +91,7 @@ describe('Cluster E2E', () => {
         it(`Cluster mode ${mode} w/ redis storage`, async () => {
             const node1 = startExposrd("node-1", network, [
                 "--log-level", "debug",
-                "--storage", "redis",
-                "--storage-redis-url", redisUrl, 
+                "--storage-url", redisUrl, 
                 "--allow-registration",
                 "--ingress", "http",
                 "--ingress-http-url", "http://localhost:8080",
@@ -102,8 +101,7 @@ describe('Cluster E2E', () => {
 
             const node2 = startExposrd("node-2", network, [
                 "--log-level", "debug",
-                "--storage", "redis",
-                "--storage-redis-url", redisUrl, 
+                "--storage-url", redisUrl, 
                 "--allow-registration",
                 "--ingress", "http",
                 "--ingress-http-url", "http://localhost:8080",

--- a/test/e2e/test_ws.js
+++ b/test/e2e/test_ws.js
@@ -24,9 +24,9 @@ describe('Websocket E2E', () => {
 
     const storageModes = [
         {storage: "In-memory storage", args: []},
-        {storage: "Redis storage", args: ["--storage", "redis", "--storage-redis-url", REDIS_URL ]},
-        {storage: "Sqlite storage", args: ["--storage", "sqlite" ]},
-        {storage: "Pgsql storage", args: ["--storage", "pgsql", "--storage-pgsql-url", PGSQL_URL ]},
+        {storage: "Redis storage", args: ["--storage-url", REDIS_URL ]},
+        {storage: "SQLite storage", args: ["--storage-url", "sqlite://db.sqlite" ]},
+        {storage: "PostgreSQL storage", args: ["--storage-url", PGSQL_URL ]},
     ];
 
     storageModes.forEach(({storage, args}) => {

--- a/test/system/storage/test_pgsql.js
+++ b/test/system/storage/test_pgsql.js
@@ -29,10 +29,8 @@ describe('pgsql storage', () => {
         config = new Config();
         clock = sinon.useFakeTimers({shouldAdvanceTime: true});
         await new Promise((resolve, reject) => {
-            storageService = new StorageService('pgsql', {
-                pgsql: {
-                    url: PGSQL_URL
-                },
+            storageService = new StorageService({
+                url: new URL(PGSQL_URL),
                 callback: (err) => err ? reject(err) : resolve()
             });
         });

--- a/test/system/storage/test_redis.js
+++ b/test/system/storage/test_redis.js
@@ -28,8 +28,8 @@ describe('redis storage', () => {
     before(async () => {
         config = new Config();
         await new Promise((resolve, reject) => {
-            storageService = new StorageService('redis', {
-                redisUrl,
+            storageService = new StorageService({
+                url: new URL(redisUrl),
                 callback: (err) => err ? reject(err) : resolve()
             });
         });

--- a/test/system/storage/test_sqlite.js
+++ b/test/system/storage/test_sqlite.js
@@ -30,8 +30,8 @@ describe('sqlite storage', () => {
         config = new Config();
         clock = sinon.useFakeTimers({shouldAdvanceTime: true});
         await new Promise((resolve, reject) => {
-            storageService = new StorageService('sqlite', {
-                sqlitePath: sqlitedb,
+            storageService = new StorageService({
+                url: new URL(`sqlite://${sqlitedb}`),
                 callback: (err) => err ? reject(err) : resolve()
             });
         });

--- a/test/unit/config/test_config.js
+++ b/test/unit/config/test_config.js
@@ -10,8 +10,7 @@ describe('configuration parser', () => {
 
         assert(config._config['cluster'] == 'redis', `cluster not set to redis, ${config._config['cluster']}`);
         assert(config._config['cluster-redis-url'] == 'redis://redis', `cluster url not set, ${config._config['cluster-redis-url']}`);
-        assert(config._config['storage'] == 'redis', `storage not set to redis, ${config._config['cluster']}`);
-        assert(config._config['storage-redis-url'] == 'redis://redis', `storage url not set, ${config._config['storage-redis-url']}`);
+        assert(config._config['storage-url'] == 'redis://redis', `storage url not set, ${config._config['storage-url']}`);
 
         config.destroy();
     });
@@ -21,50 +20,17 @@ describe('configuration parser', () => {
             "--cluster", "auto"
         ]);
 
-        assert(config._config['cluster'] == 'single-node', `cluster not set to single-node, ${config._config['cluster']}`);
+        assert(config._config['cluster'] == 'single-node', `cluster not set to single-node, got ${config._config['cluster']}`);
         config.destroy();
     });
 
-    it('--cluster auto returns redis w/ --storage redis, --cluster-redis-url', () => {
+    it('--cluster auto returns udp w/ --storage-url redis', () => {
         const config = new Config([
             "--cluster", "auto",
-            "--cluster-redis-url", "redis://redis",
-            "--storage", "redis",
-        ]);
-
-        assert(config._config['cluster'] == 'redis', `cluster not set to redis, ${config._config['cluster']}`);
-        assert(config._config['cluster-redis-url'] == 'redis://redis', `cluster-redis-url not set, ${config._config['cluster-redis-url']}`);
-        config.destroy();
-    });
-
-    it('--cluster auto returns udp w/ --storage redis', () => {
-        const config = new Config([
-            "--cluster", "auto",
-            "--storage", "redis",
+            "--storage-url", "redis://redis",
         ]);
 
         assert(config._config['cluster'] == 'udp', `cluster not set to udp, ${config._config['cluster']}`);
-        config.destroy();
-    });
-
-    it('--storage auto returns redis w/ --storage-redis-url', () => {
-        const config = new Config([
-            "--storage-redis-url", "redis://redis",
-        ]);
-
-        assert(config._config['storage'] == 'redis', `storage not set to redis, ${config._config['storage']}`);
-        assert(config._config['storage-redis-url'] == 'redis://redis', `storage-redis-url not set, ${config._config['storage-redis-url']}`);
-        config.destroy();
-    });
-
-    it('--storage redis requires --storage-redis-url', () => {
-        const config = new Config([
-            "--ingress-http-domain", "http://example.com",
-            "--storage", "redis"
-        ]);
-
-        assert(config._error.message == "Missing required argument: storage-redis-url", "argument not required");
-
         config.destroy();
     });
 
@@ -73,11 +39,9 @@ describe('configuration parser', () => {
             "--ingress-http-domain", "http://example.com",
             "--cluster", "redis"
         ]);
-
+    
         assert(config._error.message == "Missing required argument: cluster-redis-url", "argument not required");
-
+    
         config.destroy();
     });
-
-
 });

--- a/test/unit/test-utils.js
+++ b/test/unit/test-utils.js
@@ -4,7 +4,8 @@ import { Duplex } from 'stream';
 
 export const initStorageService = async () => {
     return new Promise((resolve) => {
-        const storage = new StorageService('mem', {
+        const storage = new StorageService({
+            url: new URL('memory://'),
             callback: () => { resolve(storage) }
         });
     });


### PR DESCRIPTION
Use a single configuration option (storage-url) to configure storage. The type is specified by the "protocol". Ex. redis://, or sqlite://.